### PR TITLE
chore(release): use app credentials to attach released artefact

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -66,17 +66,24 @@ jobs:
           PRIVATE_KEY_PASSWORD: ${{ secrets.PRIVATE_KEY_PASSWORD }}
         run: ./gradlew publishPlugin
 
+      - name: Generate GitHub App token
+        uses: actions/create-github-app-token@v1
+        id: generate-token
+        with:
+          app_id: ${{ secrets.REPOSITORY_BUTLER_APP_ID }}
+          private_key: ${{ secrets.REPOSITORY_BUTLER_PEM }}
+
       # Upload artifact as a release asset
       - name: Upload Release Asset
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
 
       # Create a pull request
       - name: Create Pull Request
         if: ${{ steps.properties.outputs.changelog != '' }}
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: |
           VERSION="${{ github.event.release.tag_name }}"
           BRANCH="changelog-update-$VERSION"

--- a/gradle.properties
+++ b/gradle.properties
@@ -10,7 +10,7 @@ pluginVersion = 0.1.1-SNAPSHOT
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
 pluginSinceBuild = 233
-pluginUntilBuild = 242.*
+pluginUntilBuild = 243.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC


### PR DESCRIPTION
This pull request includes changes to the GitHub Actions workflow to enhance security by generating and using a GitHub App token instead of the default GitHub token. The most important changes are:

Security improvements:

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34R69-R86): Added a step to generate a GitHub App token using the `actions/create-github-app-token@v1` action. This token is then used for uploading release assets and creating pull requests, replacing the default GitHub token.