### PR TITLE
fix(aws-cf-handling): improve error handling and validate that the aws cli is reachable

### DIFF
--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigDialog.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigDialog.kt
@@ -166,17 +166,6 @@ class EnvProviderConfigDialog(
                                 }
                             }
                         )
-                        textFieldWithBrowseButton(fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFileDescriptor()).bindText(
-                            filePathField
-                        ).validation(
-                            DialogValidation {
-                                validateIfVisible("File") {
-                                    if (filePathField.get()
-                                            .isNotBlank()
-                                    ) null else ValidationInfo("File path cannot be empty")
-                                }
-                            }
-                        )
                     }
                     row("Encoding:") { textField().bindText(encodingField) }
                 }.visible(false)

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigDialog.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigDialog.kt
@@ -6,7 +6,9 @@ import com.github.mpecan.runconfigenvinjector.state.FileEnvProviderConfig
 import com.github.mpecan.runconfigenvinjector.state.StructuredFileEnvProviderConfig
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.observable.properties.AtomicProperty
+import com.intellij.openapi.observable.util.bind
 import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.ui.validation.DialogValidation
 import com.intellij.ui.SimpleListCellRenderer
@@ -28,6 +30,8 @@ class EnvProviderConfigDialog(
     private val providerTypeField = AtomicProperty(config.type)
 
     // CodeArtifact specific fields
+    private val executablePath =
+        AtomicProperty((config as? CodeArtifactConfig)?.executablePath ?: "aws")
     private val profileField = AtomicProperty((config as? CodeArtifactConfig)?.profile ?: "default")
     private val domainField = AtomicProperty((config as? CodeArtifactConfig)?.domain ?: "")
     private val domainOwnerField =
@@ -120,10 +124,48 @@ class EnvProviderConfigDialog(
                     row("Token Duration (seconds):") {
                         intTextField(3600..43200, 3600).bindIntText(tokenDurationField)
                     }
+                    row("Executable Path:") {
+                        textField().bindText(executablePath).validation(
+                            DialogValidation {
+                                validateIfVisible("CodeArtifact") {
+                                    when {
+                                        executablePath.get()
+                                            .isBlank() -> ValidationInfo("Executable path cannot be empty")
+
+                                        executablePath.get()
+                                            .contains(" ") -> ValidationInfo("Executable path cannot contain spaces")
+
+                                        executablePath.get().let {
+                                            Runtime.getRuntime().exec("which $it").waitFor() != 0
+                                        } -> ValidationInfo("Executable path does not exist")
+
+                                        else -> null
+                                    }
+                                }
+                            }
+                        )
+                    }
                 }
 
                 filePanel = panel {
                     row("File Path:") {
+                        cell(TextFieldWithBrowseButton().apply {
+                            addBrowseFolderListener(
+                                "Select File",
+                                "Select the file to read environment variables from",
+                                null,
+                                FileChooserDescriptorFactory.createSingleFileDescriptor()
+                            )
+                            bind(envVarField)
+                        }).validation(
+                            DialogValidation {
+                                validateIfVisible("File") {
+                                    if (filePathField.get()
+                                            .isNotBlank()
+                                    ) null else ValidationInfo("File path cannot be empty")
+                                }
+                            }
+                        )
                         textFieldWithBrowseButton(fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFileDescriptor()).bindText(
                             filePathField
                         ).validation(
@@ -141,9 +183,15 @@ class EnvProviderConfigDialog(
 
                 structuredFilePanel = panel {
                     row("File Path:") {
-                        textFieldWithBrowseButton(fileChooserDescriptor = FileChooserDescriptorFactory.createSingleFileDescriptor()).bindText(
-                            filePathField
-                        ).validation(
+                        cell(TextFieldWithBrowseButton().apply {
+                            addBrowseFolderListener(
+                                "Select File",
+                                "Select the file to read environment variables from",
+                                null,
+                                FileChooserDescriptorFactory.createSingleFileDescriptor()
+                            )
+                            bind(envVarField)
+                        }).validation(
                             DialogValidation {
                                 validateIfVisible("StructuredFile") {
                                     if (filePathField.get()
@@ -198,7 +246,8 @@ class EnvProviderConfigDialog(
             region = regionField.get(),
             tokenDuration = tokenDurationField.get(),
             enabled = enabled.get(),
-            enabledRunConfigurations = enabledRunConfigurations.get()
+            enabledRunConfigurations = enabledRunConfigurations.get(),
+            executablePath = executablePath.get()
         )
 
         "File" -> FileEnvProviderConfig(

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/awscf/AwsAuthenticationHandler.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/awscf/AwsAuthenticationHandler.kt
@@ -48,4 +48,8 @@ class AwsAuthenticationHandler {
             )
         }
     }
+
+    fun isSsoExpiredOrInvalid(error: String): Boolean {
+        return error.contains("The SSO session associated with this profile has expired") || error.contains("Error loading SSO Token")
+    }
 }

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderConfig.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderConfig.kt
@@ -22,8 +22,10 @@ data class CodeArtifactConfig(
     val domain: String = "",
     val domainOwner: String = "",
     val region: String = "",
-    val tokenDuration: Int = 3600
+    val tokenDuration: Int = 3600,
+    val executablePath: String = "aws"
 ) : EnvProviderConfig {
+
     override val type: String = "CodeArtifact"
 }
 


### PR DESCRIPTION
This pull request introduces several enhancements and new features to the `EnvProviderConfigDialog` and related classes. The most significant changes include adding support for specifying an executable path in the `CodeArtifactConfig`, improving file path selection with a `TextFieldWithBrowseButton`, and handling AWS SSO session expiration more effectively.

### Enhancements to `EnvProviderConfigDialog`:

* Added `executablePath` property to `CodeArtifactConfig` and corresponding validation logic to ensure the path is valid and does not contain spaces. [[1]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309R33-R34) [[2]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309R127-R168) [[3]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309L201-R250) [[4]](diffhunk://#diff-ab5eaad5608d9a9163be36add2623d7cdcfd34f261d9d463fc3904d510e192eaL25-R28)
* Improved file path selection by replacing the existing text field with a `TextFieldWithBrowseButton` for a better user experience.

### AWS SSO Session Handling:

* Introduced method `isSsoExpiredOrInvalid` to detect expired or invalid SSO sessions.
* Enhanced `CliTokenRetriever` to handle expired SSO sessions by prompting the user to log in again and retrying the operation.