### PR TITLE
feat(use-executable-path): use the provided executable path

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,7 @@ version = providers.gradleProperty("pluginVersion").get()
 
 // Set the JVM language level used to build the project.
 kotlin {
-    jvmToolchain(17)
+    jvmToolchain(21)
 }
 
 // Configure project's dependencies

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,12 +9,12 @@ pluginVersion = 0.1.2-SNAPSHOT
 # x-release-please-end-version
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 233
-pluginUntilBuild = 243.*
+pluginSinceBuild = 242
+pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension
 platformType = IC
-platformVersion = 2023.3.8
+platformVersion = 2024.3.3
 
 # Plugin Dependencies -> https://plugins.jetbrains.com/docs/intellij/plugin-dependencies.html
 # Example: platformPlugins = com.jetbrains.php:203.4449.22, org.intellij.scala:2023.3.27@EAP

--- a/gradle.properties
+++ b/gradle.properties
@@ -9,7 +9,7 @@ pluginVersion = 0.1.2-SNAPSHOT
 # x-release-please-end-version
 
 # Supported build number ranges and IntelliJ Platform versions -> https://plugins.jetbrains.com/docs/intellij/build-number-ranges.html
-pluginSinceBuild = 242
+pluginSinceBuild = 243
 pluginUntilBuild = 251.*
 
 # IntelliJ Platform Properties -> https://plugins.jetbrains.com/docs/intellij/tools-gradle-intellij-plugin.html#configuration-intellij-extension

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigDialog.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigDialog.kt
@@ -136,7 +136,8 @@ class EnvProviderConfigDialog(
                                             .contains(" ") -> ValidationInfo("Executable path cannot contain spaces")
 
                                         executablePath.get().let {
-                                            Runtime.getRuntime().exec("which $it").waitFor() != 0
+                                            Runtime.getRuntime().exec(arrayOf("which", it))
+                                                .waitFor() != 0
                                         } -> ValidationInfo("Executable path does not exist")
 
                                         else -> null
@@ -151,10 +152,11 @@ class EnvProviderConfigDialog(
                     row("File Path:") {
                         cell(TextFieldWithBrowseButton().apply {
                             addBrowseFolderListener(
-                                "Select File",
-                                "Select the file to read environment variables from",
                                 null,
-                                FileChooserDescriptorFactory.createSingleFileDescriptor()
+                                FileChooserDescriptorFactory.createSingleFileDescriptor().apply {
+                                    title = "Select File"
+                                    description = "Select the file to read environment variables from"
+                                }
                             )
                             bind(envVarField)
                         }).validation(
@@ -174,10 +176,11 @@ class EnvProviderConfigDialog(
                     row("File Path:") {
                         cell(TextFieldWithBrowseButton().apply {
                             addBrowseFolderListener(
-                                "Select File",
-                                "Select the file to read environment variables from",
                                 null,
-                                FileChooserDescriptorFactory.createSingleFileDescriptor()
+                                FileChooserDescriptorFactory.createSingleFileDescriptor().apply {
+                                    title = "Select File"
+                                    description = "Select the file to read environment variables from"
+                                }
                             )
                             bind(envVarField)
                         }).validation(

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/awscf/CliTokenRetriever.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/awscf/CliTokenRetriever.kt
@@ -33,7 +33,7 @@ class CliTokenRetriever(
                     when {
                         authHandler.handleSsoChallenge(error)?.let { challenge ->
                             authHandler.showSsoInstructions(challenge)
-                            ProcessBuilder("aws", "sso", "login").start().waitFor()
+                            ProcessBuilder(config.executablePath, "sso", "login").start().waitFor()
                             true
                         } == true -> throw RetryableException()
 
@@ -44,7 +44,7 @@ class CliTokenRetriever(
                         }
 
                         authHandler.isSsoExpiredOrInvalid(error) -> {
-                            ProcessBuilder("aws", "sso", "login").start().also {
+                            ProcessBuilder(config.executablePath, "sso", "login").start().also {
                                 authHandler.handleSsoChallenge(
                                     it.errorStream.bufferedReader().readText()
                                 )?.let { challenge ->
@@ -83,7 +83,7 @@ class CliTokenRetriever(
                 config.profile
             )
         return listOfNotNull(
-            "aws",
+            config.executablePath,
             "codeartifact",
             "get-authorization-token",
             *profile,

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/awscf/CodeArtifactProvider.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/awscf/CodeArtifactProvider.kt
@@ -16,7 +16,7 @@ class CodeArtifactProvider(private val config: CodeArtifactConfig) :
         return try {
                 getTokenFromAwsCli(config)
         } catch (e: Exception) {
-            log.warn("Failed to get CodeArtifact token", e)
+            log.error("Failed to get CodeArtifact token", e)
             null
         }
     }


### PR DESCRIPTION
Introduces the use of the executable path provided in the configuration when dealing with AWS CF Moves to newer version as a base IDE
Deprecates old version of IDE
Improves future compatibility