### PR TITLE
feat(test-button): add a button to enable testing configuration when setting them up

### DIFF
--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigDialog.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigDialog.kt
@@ -1,18 +1,23 @@
 package com.github.mpecan.runconfigenvinjector.config
 
+import com.github.mpecan.runconfigenvinjector.service.EnvProviderFactory
 import com.github.mpecan.runconfigenvinjector.state.CodeArtifactConfig
 import com.github.mpecan.runconfigenvinjector.state.EnvProviderConfig
 import com.github.mpecan.runconfigenvinjector.state.FileEnvProviderConfig
 import com.github.mpecan.runconfigenvinjector.state.StructuredFileEnvProviderConfig
+import com.intellij.openapi.application.runInEdt
 import com.intellij.openapi.fileChooser.FileChooserDescriptorFactory
 import com.intellij.openapi.observable.properties.AtomicProperty
 import com.intellij.openapi.observable.util.bind
 import com.intellij.openapi.ui.DialogWrapper
+import com.intellij.openapi.ui.Messages
 import com.intellij.openapi.ui.TextFieldWithBrowseButton
 import com.intellij.openapi.ui.ValidationInfo
 import com.intellij.openapi.ui.validation.DialogValidation
 import com.intellij.ui.SimpleListCellRenderer
 import com.intellij.ui.dsl.builder.*
+import java.awt.event.ActionEvent
+import javax.swing.Action
 import javax.swing.JComponent
 
 class EnvProviderConfigDialog(
@@ -27,7 +32,13 @@ class EnvProviderConfigDialog(
     private val enabledRunConfigurations =
         AtomicProperty(config.enabledRunConfigurations.ifEmpty { availableRunConfigurations.keys.toList() }
             .toSet())
-    private val providerTypeField = AtomicProperty(config.type)
+    private val providerTypeField = AtomicProperty(config.type.let {
+        when (it) {
+            "File" -> "File"
+            "StructuredFile" -> "StructuredFile"
+            else -> "CodeArtifact"
+        }
+    })
 
     // CodeArtifact specific fields
     private val executablePath =
@@ -64,7 +75,7 @@ class EnvProviderConfigDialog(
     fun validateIfVisible(
         providerType: String,
         validation: () -> ValidationInfo?
-    ): ValidationInfo? = if (providerTypeField.equals(providerType)) {
+    ): ValidationInfo? = if (providerTypeField.get() == providerType) {
         validation()
     } else null
 
@@ -98,9 +109,14 @@ class EnvProviderConfigDialog(
                         textField().bindText(domainField).validation(
                             DialogValidation {
                                 validateIfVisible("CodeArtifact") {
-                                    if (domainField.get()
-                                            .isNotBlank()
-                                    ) null else ValidationInfo("Domain cannot be empty")
+                                    when {
+                                        domainField.get()
+                                            .contains(" ") -> ValidationInfo("Domain cannot contain spaces")
+
+                                        domainField.get().length < 3 -> ValidationInfo("Domain must be at least 3 characters long")
+                                        domainField.get().matches(Regex("[a-zA-Z0-9-]+")) -> null
+                                        else -> ValidationInfo("Domain can only contain alphanumeric characters and hyphens")
+                                    }
                                 }
                             }
                         )
@@ -109,9 +125,15 @@ class EnvProviderConfigDialog(
                         textField().bindText(domainOwnerField).validation(
                             DialogValidation {
                                 validateIfVisible("CodeArtifact") {
-                                    if (domainOwnerField.get()
-                                            .isNotBlank()
-                                    ) null else ValidationInfo("Domain Owner cannot be empty")
+                                    // Minimum length of 12
+                                    when {
+                                        domainOwnerField.get()
+                                            .contains(" ") -> ValidationInfo("Domain Owner cannot contain spaces")
+
+                                        domainOwnerField.get().length != 12 -> ValidationInfo("Domain Owner must be at exactly 12 characters long")
+                                        domainOwnerField.get().matches(Regex("[0-9]+")) -> null
+                                        else -> ValidationInfo("Domain Owner can only contain numbers")
+                                    }
                                 }
                             }
                         )
@@ -155,10 +177,11 @@ class EnvProviderConfigDialog(
                                 null,
                                 FileChooserDescriptorFactory.createSingleFileDescriptor().apply {
                                     title = "Select File"
-                                    description = "Select the file to read environment variables from"
+                                    description =
+                                        "Select the file to read environment variables from"
                                 }
                             )
-                            bind(envVarField)
+                            bind(filePathField)
                         }).validation(
                             DialogValidation {
                                 validateIfVisible("File") {
@@ -179,16 +202,20 @@ class EnvProviderConfigDialog(
                                 null,
                                 FileChooserDescriptorFactory.createSingleFileDescriptor().apply {
                                     title = "Select File"
-                                    description = "Select the file to read environment variables from"
+                                    description =
+                                        "Select the file to read environment variables from"
                                 }
                             )
-                            bind(envVarField)
+                            bind(filePathField)
                         }).validation(
                             DialogValidation {
                                 validateIfVisible("StructuredFile") {
-                                    if (filePathField.get()
-                                            .isNotBlank()
-                                    ) null else ValidationInfo("File path cannot be empty")
+                                  when {
+                                      filePathField.get()
+                                          .isBlank() -> ValidationInfo("File path cannot be empty")
+
+                                      else -> null
+                                  }
                                 }
                             }
                         )
@@ -199,13 +226,23 @@ class EnvProviderConfigDialog(
                             SimpleListCellRenderer.create("") { it })
                             .bindItem(structuredFormatField)
                     }
-                    row("Key:") { textField().bindText(keyField) }
+                    row("Key:") { textField().bindText(keyField).validation(
+                        DialogValidation {
+                            validateIfVisible("StructuredFile") {
+                              when{
+                                keyField.get().isBlank() -> ValidationInfo("Key cannot be empty")
+                                else -> null
+                              }
+                            }
+                        }
+                    ) }
                     row("Encoding:") { textField().bindText(encodingField) }
                 }.visible(false)
             }
+
+            row("Enable the configuration:") { checkBox("Enabled").bindSelected(enabled) }
         }
 
-        row("Enable the configuration:") { checkBox("Enabled").bindSelected(enabled) }
         group("Enabled Run Configurations") {
             panel {
                 row {
@@ -223,6 +260,38 @@ class EnvProviderConfigDialog(
         }
     }
 
+    protected inner class TestConfigurationAction : DialogWrapperAction("Test Configuration") {
+        override fun doAction(e: ActionEvent) {
+            val validationResult = doValidateAll()
+            if (validationResult.isNotEmpty()) {
+                return
+            }
+            val providerType = providerTypeField.get()
+            val config = getUpdatedConfig()
+            try {
+                EnvProviderFactory.createProvider(config).getValue()
+                runInEdt {
+                    Messages.showInfoMessage(
+                        "$providerType token retrieved successfully",
+                        "Success"
+                    )
+                }
+            } catch (e: Exception) {
+                runInEdt {
+                    Messages.showErrorDialog(
+                        "Failed to get $providerType token: ${e.message}",
+                        "Error"
+                    )
+                }
+            }
+        }
+
+    }
+
+    override fun createLeftSideActions(): Array<Action> {
+        return arrayOf(TestConfigurationAction())
+    }
+
     private fun updateVisibility(providerType: String) {
         codeArtifactPanel.visible(providerType == "CodeArtifact")
         filePanel.visible(providerType == "File")
@@ -230,38 +299,44 @@ class EnvProviderConfigDialog(
     }
 
     fun getUpdatedConfig(): EnvProviderConfig = when (providerTypeField.get()) {
-        "CodeArtifact" -> CodeArtifactConfig(
-            environmentVariable = envVarField.get(),
-            profile = profileField.get(),
-            domain = domainField.get(),
-            domainOwner = domainOwnerField.get(),
-            region = regionField.get(),
-            tokenDuration = tokenDurationField.get(),
-            enabled = enabled.get(),
-            enabledRunConfigurations = enabledRunConfigurations.get(),
-            executablePath = executablePath.get()
-        )
+        "CodeArtifact" -> constructCodeArtifactConfig()
 
-        "File" -> FileEnvProviderConfig(
-            environmentVariable = envVarField.get(),
-            enabled = enabled.get(),
-            enabledRunConfigurations = enabledRunConfigurations.get(),
-            filePath = filePathField.get(),
-            encoding = encodingField.get()
-        )
+        "File" -> constructFileEnvProviderConfig()
 
-        "StructuredFile" -> StructuredFileEnvProviderConfig(
-            environmentVariable = envVarField.get(),
-            enabled = enabled.get(),
-            enabledRunConfigurations = enabledRunConfigurations.get(),
-            filePath = filePathField.get(),
-            format = structuredFormatField.get(),
-            key = keyField.get(),
-            encoding = encodingField.get()
-        )
+        "StructuredFile" -> constructStructuredFileEnvProviderConfig()
 
         else -> throw IllegalStateException("Unknown provider type: ${providerTypeField.get()}")
     }
+
+    private fun constructStructuredFileEnvProviderConfig() = StructuredFileEnvProviderConfig(
+        environmentVariable = envVarField.get(),
+        enabled = enabled.get(),
+        enabledRunConfigurations = enabledRunConfigurations.get(),
+        filePath = filePathField.get(),
+        format = structuredFormatField.get(),
+        key = keyField.get(),
+        encoding = encodingField.get()
+    )
+
+    private fun constructFileEnvProviderConfig() = FileEnvProviderConfig(
+        environmentVariable = envVarField.get(),
+        enabled = enabled.get(),
+        enabledRunConfigurations = enabledRunConfigurations.get(),
+        filePath = filePathField.get(),
+        encoding = encodingField.get()
+    )
+
+    private fun constructCodeArtifactConfig() = CodeArtifactConfig(
+        environmentVariable = envVarField.get(),
+        profile = profileField.get(),
+        domain = domainField.get(),
+        domainOwner = domainOwnerField.get(),
+        region = regionField.get(),
+        tokenDuration = tokenDurationField.get(),
+        enabled = enabled.get(),
+        enabledRunConfigurations = enabledRunConfigurations.get(),
+        executablePath = executablePath.get()
+    )
 
     private fun isValidEnvVarName(name: String): Boolean =
         name.matches(Regex("[A-Za-z_][A-Za-z0-9_]*"))

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/ext/EnvProviderRunConfigExtension.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/ext/EnvProviderRunConfigExtension.kt
@@ -31,7 +31,7 @@ class EnvProviderRunConfigExtension : RunConfigurationExtension() {
         configService.getEnabledConfigurations().filter { config ->
             config.enabledRunConfigurations.contains(runConfigurationName)
         }.mapNotNull { config ->
-            val provider = EnvProviderFactory.getProvider(config)
+            val provider = EnvProviderFactory.createProvider(config)
             envValueCache.getValue(provider)?.let { token ->
                 config.environmentVariable to token.value
             }

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/EnvProvider.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/EnvProvider.kt
@@ -15,7 +15,7 @@ interface EnvProvider<T : EnvProviderConfig> {
 
 object EnvProviderFactory {
 
-    fun <T : EnvProviderConfig> getProvider(config: T): EnvProvider<out EnvProviderConfig> {
+    fun <T : EnvProviderConfig> createProvider(config: T): EnvProvider<out EnvProviderConfig> {
         return when(config) {
             is CodeArtifactConfig -> CodeArtifactProvider(config)
             is StructuredFileEnvProviderConfig -> StructuredFileEnvProvider(config)


### PR DESCRIPTION
Also fixed the validation to work correctly

This pull request includes several changes to the `EnvProviderConfigDialog` class and related components to improve validation, refactor configuration construction, and introduce a new action for testing configurations. The most important changes include:

### Validation Improvements:
* Enhanced validation for `domainField` to check for spaces, minimum length, and allowed characters.
* Enhanced validation for `domainOwnerField` to check for spaces, exact length of 12 characters, and allowed characters.
* Added validation for `filePathField` in both `File` and `StructuredFile` configurations to ensure the file path is not empty. [[1]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309L158-R184) [[2]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309L182-R218)
* Added validation for `keyField` in `StructuredFile` configuration to ensure the key is not empty.

### Configuration Construction Refactor:
* Refactored the construction of `EnvProviderConfig` subclasses into separate methods: `constructCodeArtifactConfig`, `constructFileEnvProviderConfig`, and `constructStructuredFileEnvProviderConfig`.

### New Test Configuration Action:
* Introduced a new `TestConfigurationAction` to test the configuration and display success or error messages based on the result.

### Method and Variable Renaming:
* Renamed `getProvider` to `createProvider` in `EnvProviderFactory` for better clarity. [[1]](diffhunk://#diff-9ceab0b4e1c88f4f93add6da21b66ce49dec2ab564fab4394ccdc3b272287698L34-R34) [[2]](diffhunk://#diff-48c4f4c54e1f92511eb62c7a20f3ce9450dae393190cfc24c91df71d2f62c5d4L18-R18)
* Changed the initialization of `providerTypeField` to map unknown types to `CodeArtifact`.

### Minor Fixes:
* Corrected the binding of `filePathField` instead of `envVarField` in `File` and `StructuredFile` configurations. [[1]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309L158-R184) [[2]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309L182-R218)

These changes collectively enhance the robustness and usability of the `EnvProviderConfigDialog` class.