### PR TITLE
fix(bug): fix bug with not being able to save

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,31 +78,3 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
         run: gh release upload ${{ github.event.release.tag_name }} ./build/distributions/*
-
-      # Create a pull request
-      - name: Create Pull Request
-        if: ${{ steps.properties.outputs.changelog != '' }}
-        env:
-          GITHUB_TOKEN: ${{ steps.generate-token.outputs.token }}
-        run: |
-          VERSION="${{ github.event.release.tag_name }}"
-          BRANCH="changelog-update-$VERSION"
-          LABEL="release changelog"
-
-          git config user.email "action@github.com"
-          git config user.name "GitHub Action"
-
-          git checkout -b $BRANCH
-          git commit -am "Changelog update - $VERSION"
-          git push --set-upstream origin $BRANCH
-          
-          gh label create "$LABEL" \
-            --description "Pull requests with release changelog update" \
-            --force \
-            || true
-
-          gh pr create \
-            --title "Changelog update - \`$VERSION\`" \
-            --body "Current pull request contains patched \`CHANGELOG.md\` file for the \`$VERSION\` version." \
-            --label "$LABEL" \
-            --head $BRANCH


### PR DESCRIPTION
This pull request includes several changes to the `EnvProviderConfigDialog` class in the `EnvProviderConfigDialog.kt` file. The changes primarily focus on refactoring code for better readability and adding validation logic for file paths.

### Code Refactoring:
* Refactored `filePathField` initialization to improve readability by restructuring the `when` clause.
* Improved the formatting of the log statement for better readability.

### Validation Logic:
* Added a new `fileFieldValidation` function to handle file path validation, ensuring that the file path is not empty.
* Updated the validation logic for `filePathField` to use the new `fileFieldValidation` function, simplifying the code. [[1]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309L195-R214) [[2]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309L220-R251)

### UI Visibility:
* Adjusted the visibility conditions for file panels based on the `providerTypeField` value to ensure the correct panel is shown. [[1]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309L181-R197) [[2]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309L195-R214) [[3]](diffhunk://#diff-524acf217de6a76c97dab34829369f359bb0933676f7017c6af4dcc1be180309L220-R251)

These changes collectively enhance the maintainability and functionality of the `EnvProviderConfigDialog` class.