### PR TITLE
fix(store-settings-correctly): store the settings in a correct manner

### DIFF
--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigTable.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigTable.kt
@@ -65,7 +65,7 @@ class EnvProviderTableModel : AbstractTableModel() {
 
     init {
         // validate and discard invalid configurations on load
-        val validConfigurations = EnvProviderSettings.getInstance().state.configurations.filter {
+        val validConfigurations = EnvProviderSettings.getInstance().state.getFromStoredConfigurations().filter {
            try {
                it.environmentVariable.isNotBlank() && it.type.isNotBlank()
            } catch (e: Exception) {
@@ -113,8 +113,8 @@ class EnvProviderTableModel : AbstractTableModel() {
     }
 
     fun applySettings() {
-        EnvProviderSettings.getInstance().state.configurations = ArrayList(configs)
+        EnvProviderSettings.getInstance().state.setToStoredConfigurations(configs)
     }
 
-    fun isModified() = EnvProviderSettings.getInstance().state.configurations != configs
+    fun isModified() = EnvProviderSettings.getInstance().state.getFromStoredConfigurations() != configs
 }

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/EnvProviderService.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/EnvProviderService.kt
@@ -8,6 +8,6 @@ import com.intellij.openapi.components.Service
 class EnvProviderService {
 
     fun getEnabledConfigurations(): List<EnvProviderConfig> {
-        return EnvProviderSettings.getInstance().state.configurations.filter { it.enabled }
+        return EnvProviderSettings.getInstance().state.getFromStoredConfigurations().filter { it.enabled }
     }
 }

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderConfig.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderConfig.kt
@@ -1,6 +1,6 @@
 package com.github.mpecan.runconfigenvinjector.state
 
-sealed interface EnvProviderConfig  {
+sealed interface EnvProviderConfig {
     val environmentVariable: String
     val enabled: Boolean
     val enabledRunConfigurations: Set<String>
@@ -10,6 +10,8 @@ sealed interface EnvProviderConfig  {
         enabled: Boolean = this.enabled,
         enabledRunConfigurations: Set<String> = this.enabledRunConfigurations
     ): EnvProviderConfig
+
+    fun toStoredConfiguration(): StoredConfiguration
 }
 
 data class BaseEnvProviderConfig(
@@ -24,6 +26,10 @@ data class BaseEnvProviderConfig(
         enabledRunConfigurations: Set<String>
     ): EnvProviderConfig {
         return BaseEnvProviderConfig(environmentVariable, enabled, enabledRunConfigurations, type)
+    }
+
+    override fun toStoredConfiguration(): StoredConfiguration {
+        throw RuntimeException("Not implemented")
     }
 }
 
@@ -45,7 +51,49 @@ data class CodeArtifactConfig(
         enabled: Boolean,
         enabledRunConfigurations: Set<String>
     ): EnvProviderConfig {
-        return CodeArtifactConfig(environmentVariable, enabled, enabledRunConfigurations, profile, domain, domainOwner, region, tokenDuration, executablePath)
+        return CodeArtifactConfig(
+            environmentVariable,
+            enabled,
+            enabledRunConfigurations,
+            profile,
+            domain,
+            domainOwner,
+            region,
+            tokenDuration,
+            executablePath
+        )
+    }
+
+    companion object {
+        fun fromStoredConfiguration(storedConfiguration: StoredConfiguration) =
+            CodeArtifactConfig(
+                storedConfiguration.environmentVariable ?: "",
+                storedConfiguration.enabled,
+                storedConfiguration.enabledRunConfigurations.toSet(),
+                storedConfiguration.additionalSettings["profile"] ?: "",
+                storedConfiguration.additionalSettings["domain"] ?: "",
+                storedConfiguration.additionalSettings["domainOwner"] ?: "",
+                storedConfiguration.additionalSettings["region"] ?: "",
+                storedConfiguration.additionalSettings["tokenDuration"]?.toIntOrNull() ?: 3600,
+                storedConfiguration.additionalSettings["executablePath"] ?: "aws"
+            )
+    }
+
+    override fun toStoredConfiguration(): StoredConfiguration {
+        return StoredConfiguration().apply {
+            this.environmentVariable = this@CodeArtifactConfig.environmentVariable
+            this.enabled = this@CodeArtifactConfig.enabled
+            this.enabledRunConfigurations = this@CodeArtifactConfig.enabledRunConfigurations.toMutableList()
+            this.type = this@CodeArtifactConfig.type
+            this.additionalSettings = mutableMapOf(
+                "profile" to this@CodeArtifactConfig.profile,
+                "domain" to this@CodeArtifactConfig.domain,
+                "domainOwner" to this@CodeArtifactConfig.domainOwner,
+                "region" to this@CodeArtifactConfig.region,
+                "tokenDuration" to this@CodeArtifactConfig.tokenDuration.toString(),
+                "executablePath" to this@CodeArtifactConfig.executablePath
+            )
+        }
     }
 }
 
@@ -62,7 +110,37 @@ data class FileEnvProviderConfig(
         enabled: Boolean,
         enabledRunConfigurations: Set<String>
     ): EnvProviderConfig {
-        return FileEnvProviderConfig(environmentVariable, enabled, enabledRunConfigurations, filePath, encoding)
+        return FileEnvProviderConfig(
+            environmentVariable,
+            enabled,
+            enabledRunConfigurations,
+            filePath,
+            encoding
+        )
+    }
+
+    companion object {
+        fun fromStoredConfiguration(storedConfiguration: StoredConfiguration) =
+            FileEnvProviderConfig(
+                storedConfiguration.environmentVariable ?: "",
+                storedConfiguration.enabled,
+                storedConfiguration.enabledRunConfigurations.toSet(),
+                storedConfiguration.additionalSettings["filePath"] ?: "",
+                storedConfiguration.additionalSettings["encoding"] ?: "UTF-8"
+            )
+    }
+
+    override fun toStoredConfiguration(): StoredConfiguration {
+        return StoredConfiguration().apply {
+            this.environmentVariable = this@FileEnvProviderConfig.environmentVariable
+            this.enabled = this@FileEnvProviderConfig.enabled
+            this.enabledRunConfigurations = this@FileEnvProviderConfig.enabledRunConfigurations.toMutableList()
+            this.type = this@FileEnvProviderConfig.type
+            this.additionalSettings = mutableMapOf(
+                "filePath" to this@FileEnvProviderConfig.filePath,
+                "encoding" to this@FileEnvProviderConfig.encoding
+            )
+        }
     }
 }
 
@@ -81,6 +159,42 @@ data class StructuredFileEnvProviderConfig(
         enabled: Boolean,
         enabledRunConfigurations: Set<String>
     ): EnvProviderConfig {
-        return StructuredFileEnvProviderConfig(environmentVariable, enabled, enabledRunConfigurations, filePath, format, key, encoding)
+        return StructuredFileEnvProviderConfig(
+            environmentVariable,
+            enabled,
+            enabledRunConfigurations,
+            filePath,
+            format,
+            key,
+            encoding
+        )
+    }
+
+    companion object {
+        fun fromStoredConfiguration(storedConfiguration: StoredConfiguration) =
+            StructuredFileEnvProviderConfig(
+                storedConfiguration.environmentVariable ?: "",
+                storedConfiguration.enabled,
+                storedConfiguration.enabledRunConfigurations.toSet(),
+                storedConfiguration.additionalSettings["filePath"] ?: "",
+                storedConfiguration.additionalSettings["format"] ?: "ENV",
+                storedConfiguration.additionalSettings["key"] ?: "",
+                storedConfiguration.additionalSettings["encoding"] ?: "UTF-8"
+            )
+    }
+
+    override fun toStoredConfiguration(): StoredConfiguration {
+        return StoredConfiguration().apply {
+            this.environmentVariable = this@StructuredFileEnvProviderConfig.environmentVariable
+            this.enabled = this@StructuredFileEnvProviderConfig.enabled
+            this.enabledRunConfigurations = this@StructuredFileEnvProviderConfig.enabledRunConfigurations.toMutableList()
+            this.type = this@StructuredFileEnvProviderConfig.type
+            this.additionalSettings = mutableMapOf(
+                "filePath" to this@StructuredFileEnvProviderConfig.filePath,
+                "format" to this@StructuredFileEnvProviderConfig.format,
+                "key" to this@StructuredFileEnvProviderConfig.key,
+                "encoding" to this@StructuredFileEnvProviderConfig.encoding
+            )
+        }
     }
 }

--- a/src/main/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderSettings.kt
+++ b/src/main/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderSettings.kt
@@ -13,7 +13,28 @@ class EnvProviderSettings : SimplePersistentStateComponent<EnvProviderState>(Env
     }
 }
 
-class EnvProviderState: BaseState() {
-    var configurations by list<EnvProviderConfig>()
+class StoredConfiguration : BaseState() {
+    var environmentVariable by string()
+    var enabled by property(true)
+    var enabledRunConfigurations by list<String>()
+    var type by string()
+    var additionalSettings by map<String, String>()
+}
+
+class EnvProviderState : BaseState() {
+    var configurations by list<StoredConfiguration>()
+
+    fun setToStoredConfigurations(configs: List<EnvProviderConfig>) {
+        configurations = configs.map { it.toStoredConfiguration() }.toMutableList()
+    }
+
+    fun getFromStoredConfigurations() = configurations.mapNotNull {
+        when (it?.type) {
+            "CodeArtifact" -> CodeArtifactConfig.fromStoredConfiguration(it)
+            "File" -> FileEnvProviderConfig.fromStoredConfiguration(it)
+            "StructuredFile" -> StructuredFileEnvProviderConfig.fromStoredConfiguration(it)
+            else -> null
+        }
+    }
 }
 

--- a/src/test/kotlin/com/github/mpecan/runconfigenvinjector/config/DialogInteractionTest.kt
+++ b/src/test/kotlin/com/github/mpecan/runconfigenvinjector/config/DialogInteractionTest.kt
@@ -12,13 +12,13 @@ class DialogInteractionTest : BasePlatformTestCase() {
     override fun setUp() {
         super.setUp()
         mockDialog = mock()
-        config = BaseEnvProviderConfig(
+        config = FileEnvProviderConfig(
             environmentVariable = "TEST_VAR",
-            type = "CodeArtifact",
             enabled = true,
-            enabledRunConfigurations = setOf()
+            enabledRunConfigurations = setOf(),
+            filePath = "test.txt"
         )
-        EnvProviderSettings.getInstance().state.configurations = mutableListOf(config)
+        EnvProviderSettings.getInstance().state.setToStoredConfigurations(mutableListOf(config))
     }
 
     fun testDialogValidationFailureFlow() {

--- a/src/test/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigTableTest.kt
+++ b/src/test/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigTableTest.kt
@@ -3,6 +3,7 @@ package com.github.mpecan.runconfigenvinjector.config
 import com.github.mpecan.runconfigenvinjector.state.BaseEnvProviderConfig
 import com.github.mpecan.runconfigenvinjector.state.EnvProviderConfig
 import com.github.mpecan.runconfigenvinjector.state.EnvProviderSettings
+import com.github.mpecan.runconfigenvinjector.state.FileEnvProviderConfig
 import com.intellij.testFramework.fixtures.BasePlatformTestCase
 import com.intellij.util.ui.UIUtil
 import org.mockito.kotlin.any
@@ -23,23 +24,23 @@ class EnvProviderConfigTableTest : BasePlatformTestCase() {
 
         // Create test configurations
         testConfigs = listOf(
-            BaseEnvProviderConfig(
+            FileEnvProviderConfig(
                 environmentVariable = "TEST_VAR_1",
-                type = "CodeArtifact",
                 enabled = true,
-                enabledRunConfigurations = setOf("MavenRunConfiguration")
+                enabledRunConfigurations = setOf("MavenRunConfiguration"),
+                filePath = "/path/to/secrets.txt"
             ),
-            BaseEnvProviderConfig(
+            FileEnvProviderConfig(
                 environmentVariable = "TEST_VAR_2",
-                type = "File",
                 enabled = false,
-                enabledRunConfigurations = setOf("GradleRunConfiguration")
+                enabledRunConfigurations = setOf("GradleRunConfiguration"),
+                filePath = "/path/to/secrets2.txt"
             )
         )
 
         // Initialize settings with test data
         val settings = EnvProviderSettings.getInstance().state
-        settings.configurations = ArrayList(testConfigs)
+        settings.setToStoredConfigurations(testConfigs)
 
         // Create table
         configurationDialog = mock<ConfigurationDialog>()
@@ -65,7 +66,7 @@ class EnvProviderConfigTableTest : BasePlatformTestCase() {
 
         // Test first row
         assertEquals("TEST_VAR_1", model.getValueAt(0, 0))
-        assertEquals("CodeArtifact", model.getValueAt(0, 1))
+        assertEquals("File", model.getValueAt(0, 1))
         assertEquals("Maven", model.getValueAt(0, 2))
         assertEquals(true, model.getValueAt(0, 3))
 

--- a/src/test/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderSettingsTest.kt
+++ b/src/test/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderSettingsTest.kt
@@ -1,0 +1,114 @@
+package com.github.mpecan.runconfigenvinjector.state
+
+import com.intellij.testFramework.fixtures.BasePlatformTestCase
+
+class EnvProviderSettingsTest : BasePlatformTestCase() {
+    private lateinit var settings: EnvProviderSettings
+    
+    override fun setUp() {
+        super.setUp()
+        settings = EnvProviderSettings.getInstance()
+    }
+    
+    fun testStoreAndRetrieveCodeArtifactConfig() {
+        val config = CodeArtifactConfig(
+            environmentVariable = "AWS_TOKEN",
+            enabled = true,
+            enabledRunConfigurations = setOf("MavenRunConfiguration", "GradleRunConfiguration"),
+            region = "us-east-1",
+            domain = "test-domain",
+            domainOwner = "123456789"
+        )
+        
+        settings.state.setToStoredConfigurations(listOf(config))
+        val retrievedConfigs = settings.state.getFromStoredConfigurations()
+        
+        assertEquals(1, retrievedConfigs.size)
+        val retrievedConfig = retrievedConfigs.first() as CodeArtifactConfig
+        assertEquals(config.environmentVariable, retrievedConfig.environmentVariable)
+        assertEquals(config.enabled, retrievedConfig.enabled)
+        assertEquals(config.enabledRunConfigurations, retrievedConfig.enabledRunConfigurations)
+        assertEquals(config.region, retrievedConfig.region)
+        assertEquals(config.domain, retrievedConfig.domain)
+        assertEquals(config.domainOwner, retrievedConfig.domainOwner)
+    }
+    
+    fun testStoreAndRetrieveFileConfig() {
+        val config = FileEnvProviderConfig(
+            environmentVariable = "API_KEY",
+            enabled = true,
+            enabledRunConfigurations = setOf("SpringBootRunConfiguration"),
+            filePath = "/path/to/secrets.txt"
+        )
+        
+        settings.state.setToStoredConfigurations(listOf(config))
+        val retrievedConfigs = settings.state.getFromStoredConfigurations()
+        
+        assertEquals(1, retrievedConfigs.size)
+        val retrievedConfig = retrievedConfigs.first() as FileEnvProviderConfig
+        assertEquals(config.environmentVariable, retrievedConfig.environmentVariable)
+        assertEquals(config.enabled, retrievedConfig.enabled)
+        assertEquals(config.enabledRunConfigurations, retrievedConfig.enabledRunConfigurations)
+        assertEquals(config.filePath, retrievedConfig.filePath)
+    }
+    
+    fun testStoreAndRetrieveStructuredFileConfig() {
+        val config = StructuredFileEnvProviderConfig(
+            environmentVariable = "DATABASE_URL",
+            enabled = true,
+            enabledRunConfigurations = setOf("DockerRunConfiguration"),
+            filePath = "/path/to/config.yaml"
+        )
+        
+        settings.state.setToStoredConfigurations(listOf(config))
+        val retrievedConfigs = settings.state.getFromStoredConfigurations()
+        
+        assertEquals(1, retrievedConfigs.size)
+        val retrievedConfig = retrievedConfigs.first() as StructuredFileEnvProviderConfig
+        assertEquals(config.environmentVariable, retrievedConfig.environmentVariable)
+        assertEquals(config.enabled, retrievedConfig.enabled)
+        assertEquals(config.enabledRunConfigurations, retrievedConfig.enabledRunConfigurations)
+        assertEquals(config.filePath, retrievedConfig.filePath)
+    }
+    
+    fun testStoreAndRetrieveMultipleConfigs() {
+        val configs = listOf(
+            CodeArtifactConfig(
+                environmentVariable = "AWS_TOKEN",
+                enabled = true,
+                enabledRunConfigurations = setOf("MavenRunConfiguration"),
+                region = "us-east-1",
+                domain = "test-domain",
+                domainOwner = "123456789"
+            ),
+            FileEnvProviderConfig(
+                environmentVariable = "API_KEY",
+                enabled = false,
+                enabledRunConfigurations = setOf("SpringBootRunConfiguration"),
+                filePath = "/path/to/secrets.txt"
+            ),
+            StructuredFileEnvProviderConfig(
+                environmentVariable = "DATABASE_URL",
+                enabled = true,
+                enabledRunConfigurations = setOf("DockerRunConfiguration"),
+                filePath = "/path/to/config.yaml"
+            )
+        )
+        
+        settings.state.setToStoredConfigurations(configs)
+        val retrievedConfigs = settings.state.getFromStoredConfigurations()
+        
+        assertEquals(3, retrievedConfigs.size)
+        assertTrue(retrievedConfigs[0] is CodeArtifactConfig)
+        assertTrue(retrievedConfigs[1] is FileEnvProviderConfig)
+        assertTrue(retrievedConfigs[2] is StructuredFileEnvProviderConfig)
+        
+        // Verify each config maintains its specific type and properties
+        retrievedConfigs.zip(configs).forEach { (retrieved, original) ->
+            assertEquals(original.environmentVariable, retrieved.environmentVariable)
+            assertEquals(original.enabled, retrieved.enabled)
+            assertEquals(original.enabledRunConfigurations, retrieved.enabledRunConfigurations)
+            assertEquals(original.type, retrieved.type)
+        }
+    }
+}

--- a/src/test/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderSettingsTest.kt
+++ b/src/test/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderSettingsTest.kt
@@ -111,4 +111,56 @@ class EnvProviderSettingsTest : BasePlatformTestCase() {
             assertEquals(original.type, retrieved.type)
         }
     }
+
+    fun testRetrieveIncompleteConfigurationCodeArtifact() {
+        val storedConfiguration = StoredConfiguration().apply {
+            this.environmentVariable = null
+            this.enabled = true
+            this.enabledRunConfigurations = mutableListOf()
+            this.type = "CodeArtifact"
+        }
+
+        CodeArtifactConfig.fromStoredConfiguration(storedConfiguration).apply {
+            assertEquals("", environmentVariable)
+            assertEquals(true, enabled)
+            assertEquals(emptySet<String>(), enabledRunConfigurations)
+            assertEquals("", region)
+            assertEquals("", domain)
+            assertEquals("", domainOwner)
+            assertEquals(3600, tokenDuration)
+            assertEquals("aws", executablePath)
+        }
+    }
+
+    fun testRetrieveIncompleteConfigurationFile() {
+        val storedConfiguration = StoredConfiguration().apply {
+            this.environmentVariable = null
+            this.enabled = true
+            this.enabledRunConfigurations = mutableListOf()
+            this.type = "File"
+        }
+
+        FileEnvProviderConfig.fromStoredConfiguration(storedConfiguration).apply {
+            assertEquals("", environmentVariable)
+            assertEquals(true, enabled)
+            assertEquals(emptySet<String>(), enabledRunConfigurations)
+            assertEquals("", filePath)
+        }
+    }
+
+    fun testRetrieveIncompleteConfigurationStructuredFile() {
+        val storedConfiguration = StoredConfiguration().apply {
+            this.environmentVariable = null
+            this.enabled = true
+            this.enabledRunConfigurations = mutableListOf()
+            this.type = "StructuredFile"
+        }
+
+        StructuredFileEnvProviderConfig.fromStoredConfiguration(storedConfiguration).apply {
+            assertEquals("", environmentVariable)
+            assertEquals(true, enabled)
+            assertEquals(emptySet<String>(), enabledRunConfigurations)
+            assertEquals("", filePath)
+        }
+    }
 }


### PR DESCRIPTION
This pull request introduces significant changes to the configuration management system for environment providers. The main goal is to transition from using direct configurations to using a new `StoredConfiguration` class for better data handling and storage. The most important changes include updating methods to use the new `StoredConfiguration` class, adding conversion functions, and updating tests accordingly.

Updates to configuration management:

* [`src/main/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigTable.kt`](diffhunk://#diff-0d0de0071fe67dedc0b895033da6e4856b831ab9bd2d80a3e4c199e66937fe93L68-R68): Replaced direct configuration handling with methods `getFromStoredConfigurations` and `setToStoredConfigurations` to use `StoredConfiguration` for validation and application of settings. [[1]](diffhunk://#diff-0d0de0071fe67dedc0b895033da6e4856b831ab9bd2d80a3e4c199e66937fe93L68-R68) [[2]](diffhunk://#diff-0d0de0071fe67dedc0b895033da6e4856b831ab9bd2d80a3e4c199e66937fe93L116-R119)
* [`src/main/kotlin/com/github/mpecan/runconfigenvinjector/service/EnvProviderService.kt`](diffhunk://#diff-cbdf2e16d58a5a3b6d46ea516e32f0bcbe7ab81a5bb9973667ddbb449ae876deL11-R11): Updated `getEnabledConfigurations` method to use `getFromStoredConfigurations` for retrieving configurations.

New methods and classes:

* [`src/main/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderConfig.kt`](diffhunk://#diff-ab5eaad5608d9a9163be36add2623d7cdcfd34f261d9d463fc3904d510e192eaR13-R14): Added `toStoredConfiguration` method to `EnvProviderConfig` and its implementations. Added companion objects with `fromStoredConfiguration` methods for converting `StoredConfiguration` back to specific config types. [[1]](diffhunk://#diff-ab5eaad5608d9a9163be36add2623d7cdcfd34f261d9d463fc3904d510e192eaR13-R14) [[2]](diffhunk://#diff-ab5eaad5608d9a9163be36add2623d7cdcfd34f261d9d463fc3904d510e192eaR30-R33) [[3]](diffhunk://#diff-ab5eaad5608d9a9163be36add2623d7cdcfd34f261d9d463fc3904d510e192eaL48-R96) [[4]](diffhunk://#diff-ab5eaad5608d9a9163be36add2623d7cdcfd34f261d9d463fc3904d510e192eaL65-R143) [[5]](diffhunk://#diff-ab5eaad5608d9a9163be36add2623d7cdcfd34f261d9d463fc3904d510e192eaL84-R198)
* [`src/main/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderSettings.kt`](diffhunk://#diff-0592be932408e79bd7b28ba2ae057a54f8ef40718cb696a6375e4f845ced8b3dR16-R38): Introduced `StoredConfiguration` class and updated `EnvProviderState` to use it. Added methods `setToStoredConfigurations` and `getFromStoredConfigurations` for handling conversions.

Test updates:

* [`src/test/kotlin/com/github/mpecan/runconfigenvinjector/config/DialogInteractionTest.kt`](diffhunk://#diff-7015d0c3bef86811b2f066fed040bedc385531f00d432a0509a35ad0f502b00fL15-R21): Updated tests to use `setToStoredConfigurations` instead of direct assignment.
* [`src/test/kotlin/com/github/mpecan/runconfigenvinjector/config/EnvProviderConfigTableTest.kt`](diffhunk://#diff-b6f4436a5fad2c67db64042e1529a2917fe6b9bb4e1cd7f2034cb4fb83d7ce81R6): Modified tests to accommodate changes in configuration handling and added necessary imports. [[1]](diffhunk://#diff-b6f4436a5fad2c67db64042e1529a2917fe6b9bb4e1cd7f2034cb4fb83d7ce81R6) [[2]](diffhunk://#diff-b6f4436a5fad2c67db64042e1529a2917fe6b9bb4e1cd7f2034cb4fb83d7ce81L26-R43) [[3]](diffhunk://#diff-b6f4436a5fad2c67db64042e1529a2917fe6b9bb4e1cd7f2034cb4fb83d7ce81L68-R69)
* [`src/test/kotlin/com/github/mpecan/runconfigenvinjector/state/EnvProviderSettingsTest.kt`](diffhunk://#diff-f8c5d5a5461cb44336bb55316c65d6d00a9fffa46650dfedb3ec92e51f298558R1-R114): Added new tests to verify the storage and retrieval of different configuration types using the new `StoredConfiguration` class.